### PR TITLE
Support newer TF versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "default" {
   #   - Bucket names must not contain uppercase characters or underscores.
   #   - Bucket names must start with a lowercase letter or number.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
-  bucket = "${var.name}"
+  bucket = var.name
 
   # S3 access control lists (ACLs) enable you to manage access to buckets and objects.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "default" {
   # Server access logging provides detailed records for the requests that are made to a bucket.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html
   logging {
-    target_bucket = "${var.logging_target_bucket}"
+    target_bucket = var.logging_target_bucket
     target_prefix = "logs/${var.name}/"
   }
 
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "default" {
   # You can, however, suspend versioning on that bucket.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
   versioning {
-    enabled = "${var.versioning_enabled}"
+    enabled = var.versioning_enabled
   }
 
   # S3 encrypts your data at the object level as it writes it to disks in its data centers
@@ -52,20 +52,20 @@ resource "aws_s3_bucket" "default" {
   # To manage your objects so that they are stored cost effectively throughout their lifecycle, configure their lifecycle.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html
   lifecycle_rule {
-    enabled = "${var.lifecycle_rule_enabled}"
-    prefix  = "${var.lifecycle_rule_prefix}"
+    enabled = var.lifecycle_rule_enabled
+    prefix  = var.lifecycle_rule_prefix
 
     # The STANDARD_IA and ONEZONE_IA storage classes are designed for long-lived and infrequently accessed data.
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-infreq-data-access
     transition {
-      days          = "${var.standard_ia_transition_days}"
+      days          = var.standard_ia_transition_days
       storage_class = "STANDARD_IA"
     }
 
     # The GLACIER storage class is suitable for archiving data where data access is infrequent.
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-glacier
     transition {
-      days          = "${var.glacier_transition_days}"
+      days          = var.glacier_transition_days
       storage_class = "GLACIER"
     }
 
@@ -76,36 +76,36 @@ resource "aws_s3_bucket" "default" {
     #     S3 removes the expired object delete marker.
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html
     expiration {
-      days = "${var.expiration_days}"
+      days = var.expiration_days
     }
 
     # Specifies when noncurrent objects transition to a specified storage class.
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions
     noncurrent_version_transition {
-      days          = "${var.glacier_noncurrent_version_transition_days}"
+      days          = var.glacier_noncurrent_version_transition_days
       storage_class = "GLACIER"
     }
 
     # Specifies when noncurrent object versions expire.
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions
     noncurrent_version_expiration {
-      days = "${var.noncurrent_version_expiration_days}"
+      days = var.noncurrent_version_expiration_days
     }
   }
 
   # A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error.
   # These objects are not recoverable.
   # https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#force_destroy
-  force_destroy = "${var.force_destroy}"
+  force_destroy = var.force_destroy
 
   # A mapping of tags to assign to the bucket.
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 # https://www.terraform.io/docs/providers/aws/r/s3_bucket_policy.html
 resource "aws_s3_bucket_policy" "default" {
-  bucket = "${aws_s3_bucket.default.id}"
-  policy = "${data.aws_iam_policy_document.default.json}"
+  bucket = aws_s3_bucket.default.id
+  policy = data.aws_iam_policy_document.default.json
 }
 
 # https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html

--- a/variables.tf
+++ b/variables.tf
@@ -3,71 +3,71 @@
 # https://www.terraform.io/docs/configuration/variables.html
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "The name of the bucket, which must comply with DNS naming conventions."
 }
 
 variable "logging_target_bucket" {
-  type        = "string"
+  type        = string
   description = "The name of the bucket that will receive the log objects."
 }
 
 variable "versioning_enabled" {
   default     = true
-  type        = "string"
+  type        = string
   description = "Enable versioning. Versioning is a means of keeping multiple variants of an object in the same bucket."
 }
 
 variable "lifecycle_rule_enabled" {
   default     = true
-  type        = "string"
+  type        = string
   description = "Specifies lifecycle rule status."
 }
 
 variable "lifecycle_rule_prefix" {
   default     = ""
-  type        = "string"
+  type        = string
   description = "Object key prefix identifying one or more objects to which the rule applies."
 }
 
 variable "standard_ia_transition_days" {
   default     = "30"
-  type        = "string"
+  type        = string
   description = "Specifies a period in the object's STANDARD_IA transitions."
 }
 
 variable "glacier_transition_days" {
   default     = "60"
-  type        = "string"
+  type        = string
   description = "Specifies a period in the object's Glacier transitions."
 }
 
 variable "expiration_days" {
   default     = "90"
-  type        = "string"
+  type        = string
   description = "Specifies a period in the object's expire."
 }
 
 variable "glacier_noncurrent_version_transition_days" {
   default     = "30"
-  type        = "string"
+  type        = string
   description = "Specifies when noncurrent object versions transitions."
 }
 
 variable "noncurrent_version_expiration_days" {
   default     = "60"
-  type        = "string"
+  type        = string
   description = "Specifies when noncurrent object versions expire."
 }
 
 variable "force_destroy" {
   default     = false
-  type        = "string"
+  type        = string
   description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error."
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map
   default     = {}
   description = "A mapping of tags to assign to the bucket."
 }


### PR DESCRIPTION
Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "map" and write
map(string) instead to explicitly indicate that the map elements are strings.